### PR TITLE
Stop excluding keyTypeData and timezoneTypes

### DIFF
--- a/exclude.txt
+++ b/exclude.txt
@@ -1566,7 +1566,6 @@ com/ibm/icu/impl/data/icudt68b/kde.res
 com/ibm/icu/impl/data/icudt68b/kde_TZ.res
 com/ibm/icu/impl/data/icudt68b/kea.res
 com/ibm/icu/impl/data/icudt68b/kea_CV.res
-com/ibm/icu/impl/data/icudt68b/keyTypeData.res
 com/ibm/icu/impl/data/icudt68b/khq.res
 com/ibm/icu/impl/data/icudt68b/khq_ML.res
 com/ibm/icu/impl/data/icudt68b/ki.res
@@ -3076,7 +3075,6 @@ com/ibm/icu/impl/data/icudt68b/th_TH_TRADITIONAL.res
 com/ibm/icu/impl/data/icudt68b/ti.res
 com/ibm/icu/impl/data/icudt68b/ti_ER.res
 com/ibm/icu/impl/data/icudt68b/ti_ET.res
-com/ibm/icu/impl/data/icudt68b/timezoneTypes.res
 com/ibm/icu/impl/data/icudt68b/tk.res
 com/ibm/icu/impl/data/icudt68b/tk_TM.res
 com/ibm/icu/impl/data/icudt68b/tl.res


### PR DESCRIPTION
Those data files are required to allow the ICU resolving extended locale tags like e.g. de_de_#u-fw-mon-mu-celsius that can occur starting from Android 14 when customising the regional preferences ([\[1\]](https://support.google.com/android/answer/12395118?hl=en), [\[2\]](https://alexzh.com/regional-preferences-in-android-14/)).

This fixes https://github.com/itkach/aard2-android/issues/175 (on my phone at least).